### PR TITLE
Create folders to serve full websites from

### DIFF
--- a/examples/css/Styles.css
+++ b/examples/css/Styles.css
@@ -1,0 +1,38 @@
+/* this is to test/show that different files are being sent and recieved with the
+# correct mime-type and usable by the browser. */
+
+*, body{ padding: 0px; margin: 0px:}
+
+.js-plotly-plot{
+    vertical-align: text-top;
+    display:inline-block;
+    margin:20px;
+    padding: 10px;
+    background: #47a0bd;
+    border: thin solid black;
+    border-radius: 5px;
+    -webkit-box-shadow: 0px 0px 16px 1px rgba(0,0,0,0.75);
+-moz-box-shadow: 0px 0px 16px 1px rgba(0,0,0,0.75);
+box-shadow: 0px 0px 16px 1px rgba(0,0,0,0.75);
+}
+#head{
+    background: #47a0bd;
+    color: white;
+    font-size: 2em;
+    padding: 5px;
+    margin: 0px;
+    font-style: oblique bold;
+}
+.textBox {
+    vertical-align: text-top;
+    max-width: 450px;
+    display:inline-block;
+    margin:20px;
+    padding: 10px;
+    background: #d4cea9;
+    border: thin solid black;
+    border-radius: 5px;
+    -webkit-box-shadow: 0px 0px 16px 1px rgba(0,0,0,0.75);
+-moz-box-shadow: 0px 0px 16px 1px rgba(0,0,0,0.75);
+box-shadow: 0px 0px 16px 1px rgba(0,0,0,0.75);
+}

--- a/examples/index.html
+++ b/examples/index.html
@@ -13,9 +13,9 @@
 <div class="textBox">This is similar to (basically a copy) the plotly.jl example but modified to
 	 demonstrate that pages and documents can effectively be fetched from within
 	 a "folder" the drawback to the method I am employing is that instead of just
-	 writing: <br>"&lt;link rel=\"stylesheet\" href=\"/css/Styles.css\" /&gt;"<br><br>
+	 writing: <br>&lt;link rel=\"stylesheet\" href=\"/css/Styles.css\" /&gt;<br><br>
 	 You have to specify the folder as well. Like this:
- 	<br>"&lt;link rel=\"stylesheet\" href=\"/MyCoolSite/css/Styles.css\" /&gt;"<br>
+ 	<br>&lt;link rel=\"stylesheet\" href=\"/MyCoolSite/css/Styles.css\" /&gt;<br>
 	It may be possible to fix this and conform more closely to standards by inserting
 	the folder name automattically before each request is sent. I'm open to suggestions!</div>
 

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+
+<html lang="en" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+	<meta charset="UTF-8">
+	<link rel="stylesheet" href="/MyCoolSite/css/Styles.css" />
+	<script src="/MyCoolSite/libs/js/pages.js"></script>
+	<script src="/MyCoolSite/libs/d3/v4.2.1/d3.min.js"></script>
+	<script src="/MyCoolSite/libs/plotly/v1.16.1/plotly.min.js"></script>
+</head>
+<body>
+<div id="head">Test PagesJL as website server!</div>
+<div class="textBox">This is similar to (basically a copy) the plotly.jl example but modified to
+	 demonstrate that pages and documents can effectively be fetched from within
+	 a "folder" the drawback to the method I am employing is that instead of just
+	 writing: <br>"&lt;link rel=\"stylesheet\" href=\"/css/Styles.css\" /&gt;"<br><br>
+	 You have to specify the folder as well. Like this:
+ 	<br>"&lt;link rel=\"stylesheet\" href=\"/MyCoolSite/css/Styles.css\" /&gt;"<br>
+	It may be possible to fix this and conform more closely to standards by inserting
+	the folder name automattically before each request is sent. I'm open to suggestions!</div>
+
+</body>
+</html>

--- a/examples/libs/js/pages.js
+++ b/examples/libs/js/pages.js
@@ -1,0 +1,60 @@
+"use strict";
+
+var Pages = (function () {
+
+    var location = window.location,
+        route = location.pathname,
+        href = location.href;
+    var sock = new WebSocket(href.replace("http","ws"));
+    sock.onmessage = function( message ){
+        var msg = JSON.parse(message.data);
+        var type = msg.type,
+            data = msg.data;
+        switch(type) {
+            case "script":
+                eval(data);
+                break
+            case "say":
+                console.log(data);
+                break
+        }
+    }
+
+    function callback(name,args) {
+        sock.send(JSON.stringify({"name":name,"route":route,"args":args}))
+    }
+    function notify(name) {
+        callback("notify",name);
+    }
+    function message(id,name,args) {
+        callback("message",[id,name,args]);
+    }
+    function broadcast(name,args) {
+        callback("broadcast",[name,args]);
+    }
+
+    sock.onopen = function () {
+        callback("connected");
+    };
+
+    window.onbeforeunload = function () {
+        callback("unloaded",route);
+    };
+
+    var addget = function (c, name) {
+		Object.defineProperty(c, name, {
+			get: function () { return eval(name); },
+			enumerable: true,
+			configurable: true
+		});
+		return c;
+	};
+
+    var c = {};
+    c = addget(c, "sock");
+    c = addget(c, "notify");
+    c = addget(c, "message");
+    c = addget(c, "broadcast");
+    c = addget(c, "callback");
+	return c;
+})();

--- a/examples/website.jl
+++ b/examples/website.jl
@@ -1,0 +1,120 @@
+using Pages, PlotlyJS
+
+Pages.start()
+# ==============================================================================
+# Example 1.
+# Type in: http://localhost:8000/SomeOtherContent?name=Travis
+# ==============================================================================
+Endpoint("/SomeOtherContent") do request::Request
+    uri = URI(request.resource)
+       param = query_params(uri)
+       "Hello $(param["name"]). I am sending you some text."
+end
+# ==============================================================================
+# Example 1.
+#  Type in: http://localhost:8000/MyCoolSite  then run: example_plotly()
+# ==============================================================================
+Endpoint("/MyCoolSite") do request::Request
+    Pages.pages["/MyCoolSite"].folder = dirname(@__FILE__)
+end
+
+# ==============================================================================
+# Shamelessly copied from existing example!
+# ==============================================================================
+function example_plotly()
+
+n = 10
+data = [scatter(;x = 1:n,y = rand(n))]
+layout = Layout(;title = "Create a new <div> and plot a single trace",
+    width = 600,
+    height = 300
+)
+id = "Plot1"
+Pages.add(Pages.Element(id=id))
+Pages.broadcast("script","""Plotly.newPlot("$(id)",$(data),$(layout));""")
+
+trace1 = scatter(;x = 1:n, y = rand(n))
+trace2 = scatter(;x = 1:n, y = rand(n))
+data = [trace1, trace2]
+layout = Layout(;title = "Create a new <div> and plot an array of traces",
+    width = 600,
+    height = 300
+)
+id = "Plot2"
+Pages.add(Pages.Element(id=id))
+Pages.broadcast("script","""Plotly.newPlot("$(id)",$(data),$(layout));""")
+
+trace1 = scatter(;
+    x = [1, 2, 3, 4],
+    y = [10, 15, 13, 17],
+    mode = "markers")
+
+trace2 = scatter(;
+    x = [2, 3, 4, 5],
+    y = [16, 5, 11, 10],
+    mode = "lines")
+
+trace3 = scatter(;
+    x = [1, 2, 3, 4],
+    y = [12, 9, 15, 12],
+    mode = "lines+markers")
+
+data = [trace1, trace2, trace3]
+
+layout = Layout(;
+    title = "Line and Scatter Plot",
+    height = 400,
+    width = 480)
+
+id = "Plot3"
+Pages.add(Pages.Element(id=id))
+Pages.broadcast("script","""Plotly.newPlot("$(id)",$(data));""")
+
+country = ["Switzerland (2011)", "Chile (2013)", "Japan (2014)",
+           "United States (2012)", "Slovenia (2014)", "Canada (2011)",
+           "Poland (2010)", "Estonia (2015)", "Luxembourg (2013)",
+           "Portugal (2011)"]
+
+votingPop = [40, 45.7, 52, 53.6, 54.1, 54.2, 54.5, 54.7, 55.1, 56.6]
+regVoters = [49.1, 42, 52.7, 84.3, 51.7, 61.1, 55.3, 64.2, 91.1, 58.9]
+
+# notice use of `attr` function to make nested attributes
+trace1 = scatter(;x=votingPop, y=country, mode="markers",
+                  name="Percent of estimated voting age population",
+                  marker=attr(color="rgba(156, 165, 196, 0.95)",
+                              line_color="rgba(156, 165, 196, 1.0)",
+                              line_width=1, size=16, symbol="circle"))
+
+trace2 = scatter(;x=regVoters, y=country, mode="markers",
+                  name="Percent of estimated registered voters")
+# also could have set the marker props above by using a dict
+trace2["marker"] = Dict(:color => "rgba(204, 204, 204, 0.95)",
+                       :line => Dict(:color=> "rgba(217, 217, 217, 1.0)",
+                                     :width=> 1),
+                       :symbol => "circle",
+                       :size => 16)
+
+data = [trace1, trace2]
+
+layout = Layout(Dict{Symbol,Any}(:paper_bgcolor => "rgb(254, 247, 234)",
+                                 :plot_bgcolor => "rgb(254, 247, 234)");
+                title="Votes cast for ten lowest voting age population in OECD countries",
+                width=600, height=600, hovermode="closest",
+                margin=Dict(:l => 140, :r => 40, :b => 50, :t => 80),
+                xaxis=attr(showgrid=false, showline=true,
+                           linecolor="rgb(102, 102, 102)",
+                           titlefont_font_color="rgb(204, 204, 204)",
+                           tickfont_font_color="rgb(102, 102, 102)",
+                           autotick=false, dtick=10, ticks="outside",
+                           tickcolor="rgb(102, 102, 102)"),
+                legend=attr(font_size=10, yanchor="middle",
+                            xanchor="right"),
+                )
+
+id = "Plot4"
+Pages.add(Pages.Element(id=id))
+Pages.broadcast("script","""Plotly.newPlot("$(id)",$(data),$(layout));""")
+
+end
+
+ # example_plotly()

--- a/src/Pages.jl
+++ b/src/Pages.jl
@@ -2,6 +2,7 @@ module Pages
 
 using HttpServer, WebSockets, URIParser, JSON, DataFrames
 using Compat; import Compat: String, @static
+import HttpServer.mimetypes
 
 export Endpoint, Callback, Request, Response, URI, query_params
 
@@ -9,9 +10,10 @@ type Endpoint
     handler::Function
     route::String
     sessions::Dict{Int,WebSocket}
+    folder::String
 
     function Endpoint(handler,route)
-        p = new(handler,route,Dict{Int,WebSocket}())
+        p = new(handler,route,Dict{Int,WebSocket}(),"")
         !haskey(pages,route) || warn("Page $route already exists.")
         pages[route] = p
         finalizer(p, p -> delete!(pages, p.route))

--- a/src/server.jl
+++ b/src/server.jl
@@ -12,8 +12,9 @@ const conditions = Dict{String,Condition}()
 conditions["connected"] = Condition()
 conditions["unloaded"] = Condition()
 
-Endpoint("/Pages.js") do request::Request
-    readstring(joinpath(dirname(@__FILE__),"Pages.js"))
+# this should no longer be nesesary ...maybe
+Endpoint("/pages.js") do request::Request
+    readstring(joinpath(dirname(@__FILE__),"/pages.js"))
 end
 
 ws = WebSocketHandler() do request::Request, client::WebSocket
@@ -40,7 +41,6 @@ http = HttpHandler() do request::Request, response::Response
         # We will be serving from folder but is a file specified?
         if length(folder) < length(route) # Yes, it is!
             file = replace(route, r"^(\/[\d\w- _]+)", "");
-            println(file)
 
         # No, no file specified so we will specify the standard default "/index.html"
         else

--- a/src/server.jl
+++ b/src/server.jl
@@ -1,4 +1,4 @@
-# Browser Window (Borrowed from Blink.jl)
+# Browser Window (Borrowed from Blink.jl)
 @static if is_apple()
     launch(x) = run(`open $x`)
 elseif is_linux()
@@ -12,13 +12,14 @@ const conditions = Dict{String,Condition}()
 conditions["connected"] = Condition()
 conditions["unloaded"] = Condition()
 
-Endpoint("/pages.js") do request::Request
-    readstring(joinpath(dirname(@__FILE__),"pages.js"))
+Endpoint("/Pages.js") do request::Request
+    readstring(joinpath(dirname(@__FILE__),"Pages.js"))
 end
 
 ws = WebSocketHandler() do request::Request, client::WebSocket
     while true
         msg = JSON.parse(String(read(client)))
+        print(msg)
         route = msg["route"]
         if !haskey(pages[route].sessions,client.id)
             pages[route].sessions[client.id] = client
@@ -29,12 +30,39 @@ end
 
 http = HttpHandler() do request::Request, response::Response
     route = URI(request.resource).path
-    if haskey(pages,route)
-        res = Response(pages[route].handler(request))
+    str = match(r"^(\/[\d\w- _]+)", route);
+    folder = String(str[1])
+
+    # We are in an existing folder
+    if haskey(pages, folder)
+        req = pages[folder].handler(request) # let's see what we're dealing with here.
+
+        # We will be serving from folder but is a file specified?
+        if length(folder) < length(route) # Yes, it is!
+            file = replace(route, r"^(\/[\d\w- _]+)", "");
+            println(file)
+
+        # No, no file specified so we will specify the standard default "/index.html"
+        else
+            file = "/index.html"
+        end
+
+        # I thought mimetypes should just work but found that I had to detect/set them
+        key = match(r"(?:\.(\w+$))", file)[1]
+        mime = mimetypes[ key ]
+
+        # Serve results
+        if length(Pages.pages[folder].folder) > 0
+            res = Response( 200, Dict{AbstractString,AbstractString}([("Content-Type", mime)]),
+                            readstring( Pages.pages[folder].folder * file ))
+        else
+            req # = "Page generated on server."
+        end
+
+    # Folder does not exist! ...Inform user.
     else
-        res = "Page not found."
+        res = "Sorry, page not found."
     end
-    res
 end
 
 server = Server(http,ws)


### PR DESCRIPTION
The project has been modified to allow the creation of "folders" which are associated with Endpoint. Any file contained in the folder can be fetched/requested as long as it is withing the actual directory associated with the Endpoint. None of this should interfere with or change the already established functionality of pages although this should be tested by someone who knows more than me about how Pages works. Some error occurred with files being served with the wrong mimeType so I also included code for detecting the file's type and ensuring that it is sent off with a corresponding mime type. There is one detail that may need attention... the requested files have to be associated with the Endpoint/folder. In other words instead of just requesting  ( /myStyles.css ) the page must request ( myCoolApp/myStyles.css ) where "/myCoolApp" is the Endpoint.