### PR TITLE
avoid chaning return type of handlers

### DIFF
--- a/examples/examples.jl
+++ b/examples/examples.jl
@@ -1,5 +1,5 @@
 Endpoint("/examples") do request::HTTP.Request
-    HTTP.Response(200,readstring(joinpath(dirname(@__FILE__),"examples.html")))
+    readstring(joinpath(dirname(@__FILE__),"examples.html"))
 end
 
 # include("plotly.jl")

--- a/examples/requests.jl
+++ b/examples/requests.jl
@@ -2,11 +2,11 @@ using JSON
 
 Endpoint("/examples/requests") do request::HTTP.Request
     if request.method == "GET"
-        response = HTTP.Response(200,readstring(joinpath(dirname(@__FILE__),"requests.html")))
+        response = readstring(joinpath(dirname(@__FILE__),"requests.html"))
     elseif request.method == "POST"
         data = String(request.body)
         println(data)
-        response = HTTP.Response(200,JSON.json(Dict(:data => data)))
+        response = JSON.json(Dict(:data => data))
     end
     response
 end

--- a/src/server.jl
+++ b/src/server.jl
@@ -13,7 +13,7 @@ conditions["connected"] = Condition()
 conditions["unloaded"] = Condition()
 
 Endpoint("/pages.js") do request::HTTP.Request
-    HTTP.Response(200,readstring(joinpath(dirname(@__FILE__),"pages.js")))
+    readstring(joinpath(dirname(@__FILE__),"pages.js"))
 end
 
 # ws = WebSocketHandler() do request::Request, client::WebSocket
@@ -38,6 +38,8 @@ function start(p = 8000)
         else
             response = HTTP.Response(404,"Not Found")
         end
-        response
+        return response isa HTTP.Response ?
+               response :
+               HTTP.Response(200, response)
     end
 end


### PR DESCRIPTION
Hi @EricForgy,
I haven't tested this, but doing it this way means you don't have to say `HTTP.Response(200, ...)` in all your handlers, and gives the users a choice between simply returning the response payload, or returning a `HTTP.Response` if they need custom headers etc.