### PR TITLE
WIP: support variable binding in routing (see #13)

### DIFF
--- a/src/Pages.jl
+++ b/src/Pages.jl
@@ -8,23 +8,69 @@ import HTTP.WebSockets.WebSocket
 
 export Endpoint, Callback, Plotly
 
+export getvar, unregister!
+
 mutable struct Endpoint
     handler::Function
-    route::String
+    route::Regex
+    routespec::String
     sessions::Dict{String,WebSocket}
 
-    function Endpoint(handler,route)
-        p = new(handler,route,Dict{String,WebSocket}())
+    function Endpoint(handler, routespec)
+        route = makeregex(routespec)
+        p = new(handler,route,routespec,Dict{String,WebSocket}())
         !haskey(pages,route) || warn("Page $route already exists.")
         pages[route] = p
         finalizer(p, p -> delete!(pages, p.route))
         p
     end
 end
-function Base.show(io::Base.IO,endpoint::Endpoint)
-    print(io,"Endpoint created at $(endpoint.route).")
+
+# unregister
+function unregister!(routespec)
+    route = makeregex(routespec)
+    delete!(pages, route)
+    nothing
 end
-const pages = Dict{String,Endpoint}() # url => page
+
+# Make regex from a route spec
+# e.g. "/ticket/<id>" => r"^/ticket/([^/]+)\$"
+function makeregex(routespec)
+    s = replace(routespec, r"\.", "\\.")
+    s = replace(s, r"<[^>]+>", "([^/]+)")
+    return Regex(string("^", s, "(\\?.*\$)*"))
+end
+
+# Returns Endpoint for the first matched route
+#
+# Due to the nature of regular expression matching, we may end up with 
+# multiple matches e.g. /examples regex could match /examples/one as well.
+# We will pick the most specific endpoint by taking the longest routespec.
+function matchroute(pages, uri)
+    matches = Endpoint[]
+    for (k, ep) in pages
+        #println("matching $k with $uri")
+        if ismatch(k, uri)
+            push!(matches, ep)
+        end
+    end
+    if length(matches) > 0
+        L = [length(ep.routespec) for ep in matches]
+        idx = indmax(L)
+        return matches[idx]
+    else
+        nothing
+    end
+end
+
+# Check if uri matches any routes in Pages
+hasroute(pages, uri) = matchroute(pages, uri) != nothing
+
+function Base.show(io::Base.IO,endpoint::Endpoint)
+    print(io,"Endpoint created at $(endpoint.routespec).")
+end
+
+const pages = Dict{Regex,Endpoint}() # url => page
 
 include("callbacks.jl")
 include("server.jl")


### PR DESCRIPTION
This implementation isn't ideal as it uses another global Dict to track parsed values.  Come to think of it we could add to the HTTP header somehow.   I can experiment with that later.

Example:
```
julia> e1 = Endpoint("/ticket/<event>/<date>") do request::HTTP.Request
         event = getvar(request, "event")
         date  = getvar(request, "date")
         "thanks for attending the _$(event)_ event on $(date)\n"
       end
Endpoint created at /ticket/<event>/<date>.
```

Test:
```
$ curl "http://localhost:8000/ticket/lakers/2018-03-01"
thanks for attending the _lakers_ event on 2018-03-01
```