### PR TITLE
support path variables

### DIFF
--- a/src/Pages.jl
+++ b/src/Pages.jl
@@ -7,17 +7,26 @@ using HTTP, JSON
 import HTTP.WebSockets.WebSocket
 
 export Endpoint, Callback, Plotly
-
+const pathVarRegex = r"\{\w+\}"
 mutable struct Endpoint
     handler::Function
     route::String
     sessions::Dict{String,WebSocket}
+    regex::Regex
 
     function Endpoint(handler,route)
         p = new(handler,route,Dict{String,WebSocket}())
-        !haskey(pages,route) || warn("Page $route already exists.")
-        pages[route] = p
-        finalizer(p, p -> delete!(pages, p.route))
+        if !ismatch(pathVarRegex, route)
+            !haskey(pages,route) || warn("Page $route already exists.")
+            pages[route] = p
+            finalizer(p, p -> delete!(pages, p.route))
+        else
+            # support path variables eg. /api/person/{persion-id}/child/{child-id}
+            p.regex = regex = Regex(replace(route, r"\{\w+\}", ".+"))
+            !haskey(regexPages,regex) || warn("Page $route ($regex) already exists.")
+            regexPages[regex] = p
+            finalizer(p, p -> delete!(regexPages, p.regex))
+        end
         p
     end
 end
@@ -25,6 +34,7 @@ function Base.show(io::Base.IO,endpoint::Endpoint)
     print(io,"Endpoint created at $(endpoint.route).")
 end
 const pages = Dict{String,Endpoint}() # url => page
+const regexPages = Dict{Regex,Endpoint}() # url regex => page
 
 include("callbacks.jl")
 include("server.jl")

--- a/src/Pages.jl
+++ b/src/Pages.jl
@@ -6,7 +6,7 @@ using HTTP, JSON
 
 import HTTP.WebSockets.WebSocket
 
-export Endpoint, Callback, Plotly
+export Endpoint, Callback, Plotly, parsePathParameters
 const pathVarRegex = r"\{\w+\}"
 mutable struct Endpoint
     handler::Function
@@ -22,7 +22,7 @@ mutable struct Endpoint
             finalizer(p, p -> delete!(pages, p.route))
         else
             # support path variables eg. /api/person/{persion-id}/child/{child-id}
-            p.regex = regex = Regex(replace(route, r"\{\w+\}", ".+"))
+            p.regex = regex = Regex(replace(route, r"\{\w+\}", "(.+)"))
             !haskey(regexPages,regex) || warn("Page $route ($regex) already exists.")
             regexPages[regex] = p
             finalizer(p, p -> delete!(regexPages, p.regex))
@@ -35,6 +35,24 @@ function Base.show(io::Base.IO,endpoint::Endpoint)
 end
 const pages = Dict{String,Endpoint}() # url => page
 const regexPages = Dict{Regex,Endpoint}() # url regex => page
+
+function parsePathParameters(request::HTTP.Request)
+    route = HTTP.URI(request.target).path
+    for (regex, p) in regexPages
+        routeMatches=match(regex, route)
+        if routeMatches != nothing
+            templateMatches=match(regex, p.route)
+            if templateMatches != nothing && length(routeMatches.captures) == length(templateMatches.captures)
+                ret = Dict()
+                for i in 1:length(routeMatches.captures)
+                    ret[templateMatches[i][2:end-1]] = routeMatches[i]
+                end
+                return ret
+            end
+        end
+    end
+    error("Could not extract path parameters from $route")
+end
 
 include("callbacks.jl")
 include("server.jl")

--- a/src/server.jl
+++ b/src/server.jl
@@ -58,6 +58,12 @@ function start(p = 8000)
             if haskey(pages,route)
                 HTTP.Servers.handle_request(pages[route].handler,http)
             else
+                for (regex, p) in regexPages
+                    if ismatch(regex, route)
+                        HTTP.Servers.handle_request(p.handler,http)
+                        return
+                    end
+                end
                 HTTP.Servers.handle_request((req) -> HTTP.Response(404),http)
             end
         end

--- a/src/server.jl
+++ b/src/server.jl
@@ -60,7 +60,8 @@ function start(p = 8000)
             else
                 for (regex, p) in regexPages
                     if ismatch(regex, route)
-                        HTTP.Servers.handle_request(p.handler,http)
+                        # TODO: maybe pass in the parsed path parameters
+                        HTTP.Servers.handle_request(p.handler, http)
                         return
                     end
                 end


### PR DESCRIPTION
Hi, 
I really like Pages.jl 
but I need REST path variables eg. :
With this template http://www.example.com/users/{userId} a client can call http://www.example.com/users/fred
( https://docs.spring.io/spring/docs/3.1.x/spring-framework-reference/htmlsingle/spring-framework-reference.html#mvc-ann-requestmapping-uri-templates )

So this pull request is a proof of concept for adding it to pages, so let me know if you'd like me to change anything.

thanks